### PR TITLE
Correcting localization for Received and Sent

### DIFF
--- a/NanoBlocks/NanoBlocks/ViewControllers/Account/TransactionTableViewCell.swift
+++ b/NanoBlocks/NanoBlocks/ViewControllers/Account/TransactionTableViewCell.swift
@@ -28,7 +28,7 @@ class TransactionTableViewCell: UITableViewCell {
         contentView.backgroundColor = .clear
         layer.cornerRadius = 10.0
         guard let tx = tx, let type = Block.BlockType(rawValue: tx.type) else { return }
-        typeLabel?.text = type == .send ? .localize("send") : .localize("receive")
+        typeLabel?.text = type == .send ? .localize("sent-filter") : .localize("received-filter")
         let secondary = Currency.secondary
         var stringValue = ""
         let value = tx.amount.bNumber.toMxrbValue


### PR DESCRIPTION
Instead of "Receive" and "Send", using "Received" and "Sent" in transaction history table.