### PR TITLE
BTC and other Minor Currency Changes

### DIFF
--- a/NanoBlocks/NanoBlocks/Utilities/Currency.swift
+++ b/NanoBlocks/NanoBlocks/Utilities/Currency.swift
@@ -11,6 +11,7 @@ import Foundation
 enum Currency: String {
     case aud
     case brl
+    case btc
     case cad
     case chf
     case clp
@@ -43,13 +44,14 @@ enum Currency: String {
     case lambo
     
     static var all: [Currency] {
-        return [.usd, .eur, .jpy, .krw, .lambo, .aud, .brl, .cad, .chf, .clp, .cny, .czk, .dkk, .gbp, .hkd, .huf, .idr, .ils, .inr, .mxn, .myr, .nok, .nzd, .php, .pkr, . pln, .rub, .sek, .sgd, .thb, .twd, .zar]
+        return [.btc, .usd, .eur, .jpy, .krw, .lambo, .aud, .brl, .cad, .chf, .clp, .cny, .czk, .dkk, .gbp, .hkd, .huf, .idr, .ils, .inr, .mxn, .myr, .nok, .nzd, .php, .pkr, . pln, .rub, .sek, .sgd, .thb, .twd, .zar]
     }
     
     var precision: Int {
         switch self {
         case .jpy, .krw: return 0
         case .lambo: return 6
+        case .btc: return 8
         default: return 2
         }
     }
@@ -57,6 +59,7 @@ enum Currency: String {
     var symbol: String {
         switch self {
         case .usd, .sgd, .cad, .hkd, .nzd, .mxn, .clp: return "$"
+        case .btc: return "₿"
         case .eur: return "€"
         case .jpy, .cny: return "¥"
         case .krw: return "₩"

--- a/NanoBlocks/NanoBlocks/Utilities/Currency.swift
+++ b/NanoBlocks/NanoBlocks/Utilities/Currency.swift
@@ -85,6 +85,15 @@ enum Currency: String {
         }
     }
     
+    /// The currency value type, while stripping redundancies (like LAMBO, chf, etc)
+    var typePostfix: String {
+        var base = rawValue.uppercased()
+        if rawValue.uppercased() != symbol.uppercased() {
+            base += " (\(symbol))"
+        }
+        return base
+    }
+    
     /// Converts a Nano (either raw or mxrb) amount to the user's selected 'secondary' currency.
     func convert(_ value: BDouble, isRaw: Bool = true) -> String {
         let value = isRaw ? value.toMxrbValue : value

--- a/NanoBlocks/NanoBlocks/ViewControllers/Account/AccountViewModel.swift
+++ b/NanoBlocks/NanoBlocks/ViewControllers/Account/AccountViewModel.swift
@@ -42,7 +42,7 @@ class AccountViewModel {
             return account.mxrbBalance.trimTrailingZeros()
         } else {
             let secondary = Currency.secondary
-            currencyValue = secondary.rawValue.uppercased() + (secondary == .lambo ? "" : " (\(secondary.symbol))")
+            currencyValue = secondary.typePostfix
             return secondary.convertToFiat(account.balance.bNumber)
         }
     }
@@ -71,7 +71,7 @@ class AccountViewModel {
             currencyValue = "NANO"
         } else {
             let secondary = Currency.secondary
-            currencyValue = secondary.rawValue.uppercased() + (secondary == .lambo ? "" : " (\(secondary.symbol))")            
+            currencyValue = secondary.typePostfix
         }
         isShowingSecondary = !isShowingSecondary
     }

--- a/NanoBlocks/NanoBlocks/ViewControllers/Accounts/AccountTableViewCell.swift
+++ b/NanoBlocks/NanoBlocks/ViewControllers/Accounts/AccountTableViewCell.swift
@@ -36,7 +36,7 @@ class AccountTableViewCell: UITableViewCell {
         var valueString = ""
         if useSecondaryCurrency {
             let secondary = Currency.secondary
-            valueString = secondary.convert(accountValue.bNumber)
+            valueString = secondary.convertToFiat(accountValue.bNumber)
             unitLabel?.text = secondary.rawValue.uppercased()
         } else {
             valueString = accountValue.bNumber.toMxrb.trimTrailingZeros()

--- a/NanoBlocks/NanoBlocks/ViewControllers/Accounts/AccountsViewModel.swift
+++ b/NanoBlocks/NanoBlocks/ViewControllers/Accounts/AccountsViewModel.swift
@@ -29,7 +29,7 @@ struct AccountsViewModel {
             let total = WalletManager.shared.accounts.reduce(BDouble(0.0), { (result, account) in
                 result + account.balance.bNumber
             })
-            balanceValue = secondary.convert(total)
+            balanceValue = secondary.convertToFiat(total)
         }
         isShowingSecondary = !isShowingSecondary
     }

--- a/NanoBlocks/NanoBlocks/ViewControllers/Accounts/AccountsViewModel.swift
+++ b/NanoBlocks/NanoBlocks/ViewControllers/Accounts/AccountsViewModel.swift
@@ -25,7 +25,7 @@ struct AccountsViewModel {
             balanceValue = getTotalNano()
         } else {
             let secondary = Currency.secondary
-            currencyValue = secondary.rawValue.uppercased() + (secondary == .lambo ? "" : " (\(secondary.symbol))")
+            currencyValue = secondary.typePostfix
             let total = WalletManager.shared.accounts.reduce(BDouble(0.0), { (result, account) in
                 result + account.balance.bNumber
             })


### PR DESCRIPTION
This PR addresses 3 things (each commit addresses 1):
•Adds BTC as a secondary currency option
•Fixes bug with using `convert` instead of `convertToFiat` on Accounts VC
•Generalizes the value string to reduce boilerplate and removes `LAMBO` specific logic to instead just look for redundant currency names (like `LAMBO (LAMBO)`)