### PR TITLE
Bugfix/amount format locale

### DIFF
--- a/NanoBlocks/NanoBlocks/Utilities/Common.swift
+++ b/NanoBlocks/NanoBlocks/Utilities/Common.swift
@@ -24,6 +24,7 @@ func nanoFormatter(_ digits: Int) -> NumberFormatter {
     numberFormatter.maximumFractionDigits = digits
     numberFormatter.minimumFractionDigits = 0
     numberFormatter.minimumIntegerDigits = 1
+    numberFormatter.decimalSeparator = "."
 
     return numberFormatter
 }
@@ -40,6 +41,7 @@ extension String {
         formatter.maximumFractionDigits = 6
         formatter.minimumFractionDigits = 0
         formatter.minimumIntegerDigits = 1
+        formatter.decimalSeparator = "."
 
         guard let value = Double(self) else {
             return "--"


### PR DESCRIPTION
Fixes an issue where users with a Locale that had a comma decimal separator would see "--" for formatted amounts. This forces a "." separator for all formatted Nano amounts.